### PR TITLE
Set Content-Type to Json prevents Errors

### DIFF
--- a/src/Service/RestService.php
+++ b/src/Service/RestService.php
@@ -83,7 +83,8 @@ class RestService
             getenv('APP_URL') . '/api/v1/' . $uri,
             [
                 'Authorization' => 'Bearer ' . $this->accessToken,
-                'Accept' => '*/*'
+                'Accept' => '*/*',
+                'Content-Type' => 'application/json'
             ],
             $body
         );


### PR DESCRIPTION
Requests will fail if body contains JSON (like in customer/login).
'Content-Type' => 'application/json' should work for all requests.